### PR TITLE
LINE Bot エコー機能の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ npm run watch
 2. 「Messaging API設定」タブでWebhook URLを設定（上記で取得したGoogle Apps ScriptのウェブアプリURL）
 3. チャネルアクセストークン（長期）を発行
 4. 応答設定で「webhook」をオンに設定
+5. Google Apps Scriptでスクリプトプロパティの設定:
+   - ブラウザでGoogle Apps Scriptエディタを開く (`npx @google/clasp open`)
+   - 「プロジェクトの設定」 > 「スクリプトプロパティ」を選択
+   - 「スクリプトプロパティを追加」をクリック
+   - 「プロパティ」欄に `LINE_CHANNEL_ACCESS_TOKEN` と入力
+   - 「値」欄にLINE Developers Consoleで発行したチャネルアクセストークンを入力
+   - 「保存」をクリック
 
 ## トラブルシューティング
 

--- a/README.md
+++ b/README.md
@@ -103,12 +103,13 @@ npm run watch
 2. 「Messaging API設定」タブでWebhook URLを設定（上記で取得したGoogle Apps ScriptのウェブアプリURL）
 3. チャネルアクセストークン（長期）を発行
 4. 応答設定で「webhook」をオンに設定
-5. Google Apps Scriptでスクリプトプロパティの設定:
+5. Google Apps Scriptでスクリプトプロパティの設定（**必須**）:
    - ブラウザでGoogle Apps Scriptエディタを開く (`npx @google/clasp open`)
    - 「プロジェクトの設定」 > 「スクリプトプロパティ」を選択
    - 「スクリプトプロパティを追加」をクリック
    - 「プロパティ」欄に `LINE_CHANNEL_ACCESS_TOKEN` と入力
    - 「値」欄にLINE Developers Consoleで発行したチャネルアクセストークンを入力
+   - 同様の手順で `LINE_BOT_USER_ID` プロパティを追加し、LINE Developers ConsoleのYour user IDを入力
    - 「保存」をクリック
 
 ## トラブルシューティング
@@ -116,6 +117,7 @@ npm run watch
 - **「global is not defined」エラー**: Google Apps Scriptでは、関数はトップレベルで定義するだけで自動的にグローバルスコープになります。明示的な`global.function`割り当ては不要です。
 - **デプロイやpushが成功しない場合**: `--force`オプションを試す（例: `npx @google/clasp push --force`）
 - **アクセス権限のエラー**: Google Apps Scriptのプロジェクト設定やデプロイ設定でアクセス権限を確認してください。
+- **「LINE_BOT_USER_ID is not set in project properties」エラー**: スクリプトプロパティに`LINE_BOT_USER_ID`を設定してください。これはLINE BotのユーザーIDで、LINE Developers ConsoleのYour user IDから取得できます。
 
 ## ライセンス
 

--- a/src/Code.ts
+++ b/src/Code.ts
@@ -1,8 +1,8 @@
 /**
  * BOTのユーザーID - LINE Developers ConsoleのYour user IDから取得
- * スクリプトプロパティから取得するように改善
+ * スクリプトプロパティから必須で設定
  */
-const BOT_USER_ID = PropertiesService.getScriptProperties().getProperty('LINE_BOT_USER_ID') || 'UDEADBEEFDEADBEEFDEADBEEFDEADBEEF';
+const BOT_USER_ID = PropertiesService.getScriptProperties().getProperty('LINE_BOT_USER_ID');
 
 // LINE Messaging API関連の型定義
 interface LineWebhookEvent {
@@ -105,6 +105,12 @@ function doGet(e: GoogleAppsScript.Events.DoGet): GoogleAppsScript.Content.TextO
 function doPost(e: GoogleAppsScript.Events.DoPost) {
   // リクエストデータの詳細をログに記録
   console.log('Received webhook data:', JSON.stringify(e.postData));
+  
+  // BOT_USER_IDが設定されているか確認
+  if (!BOT_USER_ID) {
+    console.error('Error: LINE_BOT_USER_ID is not set in project properties');
+    return;
+  }
   
   // すべてのケースで200 OKを返す（空のreturnで302を防ぐ）
   

--- a/src/Code.ts
+++ b/src/Code.ts
@@ -53,22 +53,17 @@ function doGet(e: GoogleAppsScript.Events.DoGet): GoogleAppsScript.Content.TextO
 /**
  * doPost - Handle POST requests from LINE platform
  * @param e - Event object from Google Apps Script
- * @returns {GoogleAppsScript.Content.TextOutput} Response with status
  */
-function doPost(e: GoogleAppsScript.Events.DoPost): GoogleAppsScript.Content.TextOutput {
+function doPost(e: GoogleAppsScript.Events.DoPost) {
   // リクエストデータの詳細をログに記録
   console.log('Received webhook data:', JSON.stringify(e.postData));
   
-  // 検証で200を返すための取り組み
-  if (typeof e.parameter?.replyToken === 'undefined') {
-    return ContentService.createTextOutput(JSON.stringify({ status: 'success' }))
-      .setMimeType(ContentService.MimeType.JSON);
-  }
+  // すべてのケースで200 OKを返す（空のreturnで302を防ぐ）
   
-  // リクエストデータがない場合は400エラー
+  // リクエストデータがない場合
   if (!e.postData) {
-    return ContentService.createTextOutput(JSON.stringify({ status: 'error', message: 'No post data' }))
-      .setMimeType(ContentService.MimeType.JSON);
+    console.log('No post data');
+    return;
   }
 
   try {
@@ -78,10 +73,10 @@ function doPost(e: GoogleAppsScript.Events.DoPost): GoogleAppsScript.Content.Tex
     // パースしたデータをログに記録
     console.log('Parsed webhook data:', JSON.stringify(requestData));
     
-    // イベントがない場合は200で終了（LINEの接続確認など）
+    // イベントがない場合は終了（LINEの接続確認など）
     if (!requestData.events || requestData.events.length === 0) {
-      return ContentService.createTextOutput(JSON.stringify({ status: 'success', message: 'No events' }))
-        .setMimeType(ContentService.MimeType.JSON);
+      console.log('No events in request');
+      return;
     }
 
     // 各イベントを処理
@@ -99,18 +94,12 @@ function doPost(e: GoogleAppsScript.Events.DoPost): GoogleAppsScript.Content.Tex
         }
       }
     }
-
-    return ContentService.createTextOutput(JSON.stringify({ status: 'success' }))
-      .setMimeType(ContentService.MimeType.JSON);
-      
+    
+    // 正常終了
+    
   } catch (error: any) {
     // エラーが発生した場合はログに記録
     console.error('Error processing request:', error);
-    return ContentService.createTextOutput(JSON.stringify({ 
-      status: 'error', 
-      message: error?.message || 'Unknown error occurred'
-    }))
-      .setMimeType(ContentService.MimeType.JSON);
   }
 }
 

--- a/src/Code.ts
+++ b/src/Code.ts
@@ -90,10 +90,13 @@ function doPost(e: GoogleAppsScript.Events.DoPost): GoogleAppsScript.Content.Tex
     return ContentService.createTextOutput(JSON.stringify({ status: 'success' }))
       .setMimeType(ContentService.MimeType.JSON);
       
-  } catch (error) {
+  } catch (error: any) {
     // エラーが発生した場合はログに記録
     console.error('Error processing request:', error);
-    return ContentService.createTextOutput(JSON.stringify({ status: 'error', message: error.toString() }))
+    return ContentService.createTextOutput(JSON.stringify({ 
+      status: 'error', 
+      message: error?.message || 'Unknown error occurred'
+    }))
       .setMimeType(ContentService.MimeType.JSON);
   }
 }
@@ -134,7 +137,7 @@ function replyMessage(replyToken: string, messages: LineReplyMessage[]): void {
     if (responseCode < 200 || responseCode >= 300) {
       console.error(`Error sending reply: ${response.getContentText()}`);
     }
-  } catch (error) {
+  } catch (error: any) {
     console.error('Error sending reply:', error);
   }
 }

--- a/src/Code.ts
+++ b/src/Code.ts
@@ -59,8 +59,7 @@ function doPost(e: GoogleAppsScript.Events.DoPost): GoogleAppsScript.Content.Tex
   // リクエストデータがない場合は400エラー
   if (!e.postData) {
     return ContentService.createTextOutput(JSON.stringify({ status: 'error', message: 'No post data' }))
-      .setMimeType(ContentService.MimeType.JSON)
-      .setStatusCode(400);
+      .setMimeType(ContentService.MimeType.JSON);
   }
 
   try {
@@ -95,8 +94,7 @@ function doPost(e: GoogleAppsScript.Events.DoPost): GoogleAppsScript.Content.Tex
     // エラーが発生した場合はログに記録
     console.error('Error processing request:', error);
     return ContentService.createTextOutput(JSON.stringify({ status: 'error', message: error.toString() }))
-      .setMimeType(ContentService.MimeType.JSON)
-      .setStatusCode(500);
+      .setMimeType(ContentService.MimeType.JSON);
   }
 }
 

--- a/src/Code.ts
+++ b/src/Code.ts
@@ -4,6 +4,12 @@
  */
 const BOT_USER_ID = PropertiesService.getScriptProperties().getProperty('LINE_BOT_USER_ID');
 
+/**
+ * LINEチャンネルアクセストークン - LINE Developers Consoleから取得
+ * スクリプトプロパティから必須で設定
+ */
+const CHANNEL_ACCESS_TOKEN = PropertiesService.getScriptProperties().getProperty('LINE_CHANNEL_ACCESS_TOKEN');
+
 // LINE Messaging API関連の型定義
 interface LineWebhookEvent {
   type: string;
@@ -109,6 +115,12 @@ function doPost(e: GoogleAppsScript.Events.DoPost) {
   // BOT_USER_IDが設定されているか確認
   if (!BOT_USER_ID) {
     console.error('Error: LINE_BOT_USER_ID is not set in project properties');
+    return;
+  }
+  
+  // CHANNEL_ACCESS_TOKENが設定されているか確認
+  if (!CHANNEL_ACCESS_TOKEN) {
+    console.error('Error: LINE_CHANNEL_ACCESS_TOKEN is not set in project properties');
     return;
   }
   

--- a/src/Code.ts
+++ b/src/Code.ts
@@ -1,6 +1,45 @@
 /**
+ * LINE Bot for my family
  * Google Apps Script entry point for HTTP requests
  */
+
+// LINE Messaging API関連の型定義
+interface LineWebhookEvent {
+  type: string;
+  message?: LineMessage;
+  replyToken?: string;
+  source: {
+    type: string;
+    userId?: string;
+    groupId?: string;
+    roomId?: string;
+  };
+  timestamp: number;
+}
+
+interface LineMessage {
+  type: string;
+  id: string;
+  text?: string;
+}
+
+interface LineWebhookRequest {
+  destination: string;
+  events: LineWebhookEvent[];
+}
+
+interface LineReplyMessage {
+  type: string;
+  text?: string;
+  originalContentUrl?: string;
+  previewImageUrl?: string;
+  // 他のメッセージタイプのプロパティも必要に応じて追加
+}
+
+interface LineReplyRequest {
+  replyToken: string;
+  messages: LineReplyMessage[];
+}
 
 /**
  * doGet - Handle GET requests
@@ -8,17 +47,96 @@
  * @returns {GoogleAppsScript.Content.TextOutput} Response with Hello World text
  */
 function doGet(e: GoogleAppsScript.Events.DoGet): GoogleAppsScript.Content.TextOutput {
-  return ContentService.createTextOutput('Hello World');
+  return ContentService.createTextOutput('LINE Bot is running!');
 }
 
 /**
- * doPost - Handle POST requests
+ * doPost - Handle POST requests from LINE platform
  * @param e - Event object from Google Apps Script
- * @returns {GoogleAppsScript.Content.TextOutput} Response with Hello World text
+ * @returns {GoogleAppsScript.Content.TextOutput} Response with status
  */
 function doPost(e: GoogleAppsScript.Events.DoPost): GoogleAppsScript.Content.TextOutput {
-  return ContentService.createTextOutput('Hello World');
+  // リクエストデータがない場合は400エラー
+  if (!e.postData) {
+    return ContentService.createTextOutput(JSON.stringify({ status: 'error', message: 'No post data' }))
+      .setMimeType(ContentService.MimeType.JSON)
+      .setStatusCode(400);
+  }
+
+  try {
+    // LINE Webhookからのリクエストをパース
+    const requestData: LineWebhookRequest = JSON.parse(e.postData.contents);
+    
+    // イベントがない場合は200で終了（LINEの接続確認など）
+    if (!requestData.events || requestData.events.length === 0) {
+      return ContentService.createTextOutput(JSON.stringify({ status: 'success', message: 'No events' }))
+        .setMimeType(ContentService.MimeType.JSON);
+    }
+
+    // 各イベントを処理
+    for (const event of requestData.events) {
+      // メッセージイベントのみ処理
+      if (event.type === 'message' && event.message && event.replyToken) {
+        // テキストメッセージのみ応答
+        if (event.message.type === 'text' && event.message.text) {
+          // 受信したテキストをそのまま返信
+          replyMessage(event.replyToken, [{
+            type: 'text',
+            text: event.message.text
+          }]);
+        }
+      }
+    }
+
+    return ContentService.createTextOutput(JSON.stringify({ status: 'success' }))
+      .setMimeType(ContentService.MimeType.JSON);
+      
+  } catch (error) {
+    // エラーが発生した場合はログに記録
+    console.error('Error processing request:', error);
+    return ContentService.createTextOutput(JSON.stringify({ status: 'error', message: error.toString() }))
+      .setMimeType(ContentService.MimeType.JSON)
+      .setStatusCode(500);
+  }
 }
 
-// Note: In Google Apps Script, functions defined at the top level
-// are automatically exposed globally. No need to explicitly assign them.
+/**
+ * LINE Messaging APIを使ってメッセージを返信する
+ * @param replyToken - 返信用トークン
+ * @param messages - 送信するメッセージの配列
+ */
+function replyMessage(replyToken: string, messages: LineReplyMessage[]): void {
+  // チャンネルアクセストークンをプロジェクトプロパティから取得
+  const channelAccessToken = PropertiesService.getScriptProperties().getProperty('LINE_CHANNEL_ACCESS_TOKEN');
+  
+  if (!channelAccessToken) {
+    console.error('Channel access token is not set in project properties');
+    return;
+  }
+  
+  const url = 'https://api.line.me/v2/bot/message/reply';
+  const payload: LineReplyRequest = {
+    replyToken: replyToken,
+    messages: messages
+  };
+  
+  const options: GoogleAppsScript.URL_Fetch.URLFetchRequestOptions = {
+    method: 'post',
+    contentType: 'application/json',
+    headers: {
+      'Authorization': `Bearer ${channelAccessToken}`
+    },
+    payload: JSON.stringify(payload)
+  };
+  
+  try {
+    const response = UrlFetchApp.fetch(url, options);
+    const responseCode = response.getResponseCode();
+    
+    if (responseCode < 200 || responseCode >= 300) {
+      console.error(`Error sending reply: ${response.getContentText()}`);
+    }
+  } catch (error) {
+    console.error('Error sending reply:', error);
+  }
+}


### PR DESCRIPTION
## 変更内容

- LINE Messaging API を使用したエコー機能の実装
- 受信したメッセージをそのまま返信する機能
- チャンネルアクセストークンをスクリプトプロパティから取得するよう設定
- READMEにスクリプトプロパティの設定方法を追加

## 動作確認方法

1. LINE Developers Consoleでチャネルを作成・設定
2. GASのスクリプトプロパティにをキーとして設定
3. LINEからメッセージを送信すると、同じメッセージが返信されることを確認

## 備考

- LINE Developer ページから取得した USER ID だとうまくいかず, WEBHOOK のログから直接取得した USER ID をスクリプトプロパティに設定した